### PR TITLE
chore: update Facebook API version and dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 python = ">=3.8"
 requests = "~=2.31.0"
 singer-sdk = ">=0.27,<0.36"
-facebook-business = "^19.0.0"
+facebook-business = "^21.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=7.4.1"

--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -47,6 +47,14 @@ EXCLUDED_FIELDS = [
     "__module__",
     "__doc__",
     "__dict__",
+    "age_targeting", 
+    'gender_targeting', 
+    "labels",
+    "location",
+    "estimated_ad_recall_rate_lower_bound",
+    "estimated_ad_recall_rate_upper_bound",
+    "estimated_ad_recallers_lower_bound",
+    "estimated_ad_recallers_upper_bound",
 ]
 
 SLEEP_TIME_INCREMENT = 5
@@ -312,7 +320,9 @@ class AdsInsightStream(Stream):
         """
         # Make a GET request to the Facebook Graph API to retrieve the usage limit
         check = rq.get(
-            'https://graph.facebook.com/v19.0/act_' +
+            'https://graph.facebook.com/' +
+            self.config["api_version"] +
+            '/act_' +
             self.config["account_id"] +
             '/insights?access_token=' +
             self.config["access_token"]

--- a/tap_facebook/tap.py
+++ b/tap_facebook/tap.py
@@ -67,7 +67,7 @@ class TapFacebook(Tap):
             "api_version",
             th.StringType,
             description="The API version to request data from.",
-            default="v18.0",
+            default="v21.0",
         ),
         th.Property(
             "account_id",


### PR DESCRIPTION
- Updated facebook-business dependency from ^19.0.0 to ^21.0.0 in pyproject.toml.
- Changed default API version in TapFacebook class from v18.0 to v21.0.
- Excluded additional fields in ad insights stream and adjusted API request URL to use the new version.

These changes ensure compatibility with the latest Facebook API updates.