### PR TITLE
Feature/hgi 7439 - Support `account_ids` or lack of `account_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 |:--------------------|:--------:|:-------:|:------------|
 | access_token        | True     | None    | The token to authenticate against the API service |
 | api_version         | False    | v16.0   | The API version to request data from. |
-| account_id          | True     | None    | Your Facebook Account ID. |
+| account_id          | False    | None    | Your Facebook Account ID. |
+| account_ids         | False    | None    | Comma separated list of Facebook Account IDs. |
 | start_date          | False    | None    | The earliest record date to sync |
 | end_date            | False    | None    | The latest record date to sync |
 | stream_maps         | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
@@ -37,6 +38,17 @@ pipx install git+https://github.com/MeltanoLabs/tap-facebook.git
 ```
 
 ## Configuration
+
+
+### Account Ids
+
+By default, this tap will fetch the selected streams for **all** Facebook account ids accessible with your authenticated credentials.
+
+You can limit this by specifying one of two config flags:
+
+1. `account_id`: The id for the account you wish to sync.
+2. `account_ids` A comma separated string of all the accounts you want to sync.
+
 
 ### Meltano Variables
 

--- a/tap_facebook/streams/ad_accounts.py
+++ b/tap_facebook/streams/ad_accounts.py
@@ -38,9 +38,6 @@ class AdAccountsStream(FacebookStream):
 
     @property
     def columns(self) -> list[str]:
-        if not self.selected:
-            return ["id", "name", "account_id"]
-        
         columns = [
         "account_id",
         "business_name",
@@ -239,6 +236,13 @@ class AdAccountsStream(FacebookStream):
         )
         row["spend_cap"] = int(row["spend_cap"]) if "spend_cap" in row else None
         return row
+
+    def get_records(self, context):
+        if self.selected == False and self.configured_account_ids:
+            for account_id in self.configured_account_ids:
+                yield {"account_id": account_id}
+        else:
+            yield from super().get_records(context)
 
     def get_url_params(
         self,

--- a/tap_facebook/streams/ad_accounts.py
+++ b/tap_facebook/streams/ad_accounts.py
@@ -246,3 +246,23 @@ class AdAccountsStream(FacebookStream):
             params["after"] = next_page_token
 
         return params
+
+
+    def get_child_context(self, record, context):
+        return {"account_id": record["account_id"]}
+    
+
+    def _sync_children(self, child_context: dict | None) -> None:
+        if not child_context:
+            return
+        
+        if self.config.get("account_id"):
+            if not child_context["account_id"] == self.config.get("account_id"):
+                return
+        
+        if self.config.get("account_ids"):
+            specified_account_ids = [id.strip() for id in self.config.get("account_ids").split(",")]
+            if not child_context["account_id"] in specified_account_ids:
+                return
+        
+        super()._sync_children(child_context)

--- a/tap_facebook/streams/ad_accounts.py
+++ b/tap_facebook/streams/ad_accounts.py
@@ -124,6 +124,8 @@ class AdAccountsStream(FacebookStream):
         "tax_id",
         ]
             
+        # Owner field throws 403 if queried without permission
+        # Only sync if explicitly selected
         if self.mask.get(('properties', 'owner')) == False:
             columns = [col for col in columns if col != "owner"]
 

--- a/tap_facebook/streams/ad_images.py
+++ b/tap_facebook/streams/ad_images.py
@@ -13,9 +13,10 @@ from singer_sdk.typing import (
 )
 
 from tap_facebook.client import FacebookStream
+from tap_facebook.streams.base_streams import AccountLevelStream
 
 
-class AdImages(FacebookStream):
+class AdImages(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/ad-image/."""
 
     """

--- a/tap_facebook/streams/ad_labels.py
+++ b/tap_facebook/streams/ad_labels.py
@@ -8,10 +8,10 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import FacebookStream
 
+from tap_facebook.streams.base_streams import AccountLevelStream
 
-class AdLabelsStream(FacebookStream):
+class AdLabelsStream(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/ad-creative/."""
 
     """

--- a/tap_facebook/streams/ad_videos.py
+++ b/tap_facebook/streams/ad_videos.py
@@ -15,10 +15,10 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import FacebookStream
+from tap_facebook.streams.base_streams import AccountLevelStream
 
 
-class AdVideos(FacebookStream):
+class AdVideos(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/ad-image/."""
 
     """

--- a/tap_facebook/streams/ads.py
+++ b/tap_facebook/streams/ads.py
@@ -12,7 +12,7 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import IncrementalFacebookStream
+from tap_facebook.streams.base_streams import IncrementalFacebookStream
 
 
 class AdsStream(IncrementalFacebookStream):

--- a/tap_facebook/streams/adsets.py
+++ b/tap_facebook/streams/adsets.py
@@ -14,7 +14,7 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import IncrementalFacebookStream
+from tap_facebook.streams.base_streams import IncrementalFacebookStream
 
 
 class AdsetsStream(IncrementalFacebookStream):

--- a/tap_facebook/streams/base_streams.py
+++ b/tap_facebook/streams/base_streams.py
@@ -1,0 +1,49 @@
+import typing as t
+import json
+import pendulum
+from tap_facebook.client import FacebookStream
+from tap_facebook.streams import AdAccountsStream
+
+class AccountLevelStream(FacebookStream):
+    """Account level stream class."""
+    parent_stream_type = AdAccountsStream
+
+    @property
+    def url_base(self) -> str:
+        return super().url_base + "/act_{account_id}"
+
+class IncrementalFacebookStream(AccountLevelStream):
+    def get_url_params(
+        self,
+        context: dict | None,
+        next_page_token: t.Any | None,  # noqa: ANN401
+    ) -> dict[str, t.Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+
+        Args:
+            context: The stream context.
+            next_page_token: The next page index or value.
+
+        Returns:
+            A dictionary of URL query parameters.
+        """
+        params: dict = {"limit": 25}
+        if next_page_token is not None:
+            params["after"] = next_page_token
+        if self.replication_key:
+            params["sort"] = "asc"
+            params["order_by"] = self.replication_key
+            ts = pendulum.parse(self.get_starting_replication_key_value(context))
+            params["filtering"] = json.dumps(
+                [
+                    {
+                        "field": f"{self.filter_entity}.{self.replication_key}",
+                        "operator": "GREATER_THAN",
+                        "value": int(ts.timestamp()),
+                    },
+                ],
+            )
+
+        return params
+
+

--- a/tap_facebook/streams/campaign.py
+++ b/tap_facebook/streams/campaign.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from singer_sdk import typing as th  # JSON Schema typing helpers
 from singer_sdk.streams.core import REPLICATION_INCREMENTAL
 
-from tap_facebook.client import IncrementalFacebookStream
+from tap_facebook.streams.base_streams import IncrementalFacebookStream
 
 
 class CampaignStream(IncrementalFacebookStream):

--- a/tap_facebook/streams/creative.py
+++ b/tap_facebook/streams/creative.py
@@ -12,10 +12,10 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import FacebookStream
+from tap_facebook.streams.base_streams import AccountLevelStream
 
 
-class CreativeStream(FacebookStream):
+class CreativeStream(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/ad-creative/."""
 
     """

--- a/tap_facebook/streams/custom_audiences.py
+++ b/tap_facebook/streams/custom_audiences.py
@@ -14,10 +14,10 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import FacebookStream
+from tap_facebook.streams.base_streams import AccountLevelStream
 
 
-class CustomAudiences(FacebookStream):
+class CustomAudiences(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/custom-audience/."""
 
     """

--- a/tap_facebook/streams/custom_conversions.py
+++ b/tap_facebook/streams/custom_conversions.py
@@ -11,10 +11,10 @@ from singer_sdk.typing import (
     StringType,
 )
 
-from tap_facebook.client import FacebookStream
+from tap_facebook.streams.base_streams import AccountLevelStream
 
 
-class CustomConversions(FacebookStream):
+class CustomConversions(AccountLevelStream):
     """https://developers.facebook.com/docs/marketing-api/reference/custom-audience/."""
 
     """

--- a/tap_facebook/tap.py
+++ b/tap_facebook/tap.py
@@ -70,12 +70,6 @@ class TapFacebook(Tap):
             default="v21.0",
         ),
         th.Property(
-            "account_id",
-            th.StringType,
-            description="Your Facebook Account ID.",
-            required=True,
-        ),
-        th.Property(
             "insight_reports_list",
             th.ArrayType(
                 th.ObjectType(


### PR DESCRIPTION
This PR:
- Supports the use of a comma seperated list of `account_ids`
- Sets the AdAccounts stream to be a parent of the report streams
- Avoids querying `owner` field on AdAccounts when not explicitly selected -- This avoids an error when `business_manager` scope is missing from the oAuth app