### PR TITLE
HGI-7439-2 - Remove owner field from AdAccounts Stream

### DIFF
--- a/tap_facebook/streams/ad_accounts.py
+++ b/tap_facebook/streams/ad_accounts.py
@@ -69,7 +69,6 @@ class AdAccountsStream(FacebookStream):
         "min_daily_budget",
         "name",
         "offsite_pixels_tos_accepted",
-        "owner",
         "spend_cap",
         "tax_id_status",
         "tax_id_type",
@@ -120,12 +119,7 @@ class AdAccountsStream(FacebookStream):
         "business_zip",
         "tax_id",
         ]
-            
-        # Owner field throws 403 if queried without permission
-        # Only sync if explicitly selected
-        if self.mask.get(('properties', 'owner')) == False:
-            columns = [col for col in columns if col != "owner"]
-
+        
         return columns
 
     name = "adaccounts"
@@ -167,7 +161,6 @@ class AdAccountsStream(FacebookStream):
         Property("min_daily_budget", IntegerType),
         Property("name", StringType),
         Property("offsite_pixels_tos_accepted", BooleanType),
-        Property("owner", StringType),
         Property("spend_cap", IntegerType),
         Property("tax_id_status", IntegerType),
         Property("tax_id_type", StringType),


### PR DESCRIPTION
This PR removes the `owner` field from the `AdAccounts` stream because Facebook Ads will not return certain records when it is included in the AdAccounts query